### PR TITLE
Replace io bytes with str

### DIFF
--- a/kindle.py
+++ b/kindle.py
@@ -47,8 +47,8 @@ def export_txt(clips):
             lines.append(clips[book][pos].encode('utf-8'))
 
         filename = os.path.join(OUTPUT_DIR, u"%s.md" % book)
-        with open(filename, 'wb') as f:
-            f.write("\n\n---\n\n".join(lines))
+        with open(filename, 'w') as f:
+            f.write("\n\n---\n\n".join(str(lines)))
 
 
 def load_clips():
@@ -66,7 +66,7 @@ def save_clips(clips):
     """
     Save new clips to DATA_FILE
     """
-    with open(DATA_FILE, 'wb') as f:
+    with open(DATA_FILE, 'w') as f:
         json.dump(clips, f)
 
 


### PR DESCRIPTION
Hi @MilkShakeYoung, thanks for sharing this handy script

I've replaced:

[1] 'wb' with 'w' when opening files in response to:

```python-traceback
In [5]: run kindle.py                                                                           
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
~/Documents/my-code/kindle-clippings/kindle-clippings/kindle.py in <module>
     92 
     93 if __name__ == '__main__':
---> 94     main()

~/Documents/my-code/kindle-clippings/kindle-clippings/kindle.py in main()
     87 
     88     # save/export clips
---> 89     save_clips(clips)
     90     export_txt(clips)
     91 

~/Documents/my-code/kindle-clippings/kindle-clippings/kindle.py in save_clips(clips)
     68     """
     69     with open(DATA_FILE, 'wb') as f:
---> 70         json.dump(clips, f)
     71 
     72 

~/miniconda3/envs/kindle/lib/python3.8/json/__init__.py in dump(obj, fp, skipkeys, ensure_ascii, check_circular, allow_nan, cls, indent, separators, default, sort_keys, **kw)
    178     # a debuggability cost
    179     for chunk in iterable:
--> 180         fp.write(chunk)
    181 
    182 

TypeError: a bytes-like object is required, not 'str'
```

[2] lines with str(lines) to so writing a string to file instead of bytes in response to:

```python-traceback
In [9]: run kindle.py                                                                           
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
~/Documents/my-code/kindle-clippings/kindle-clippings/kindle.py in <module>
     92 
     93 if __name__ == '__main__':
---> 94     main()

~/Documents/my-code/kindle-clippings/kindle-clippings/kindle.py in main()
     88     # save/export clips
     89     save_clips(clips)
---> 90     export_txt(clips)
     91 
     92 

~/Documents/my-code/kindle-clippings/kindle-clippings/kindle.py in export_txt(clips)
     49         filename = os.path.join(OUTPUT_DIR, u"%s.md" % book)
     50         with open(filename, 'w') as f:
---> 51             f.write("\n\n---\n\n".join(lines))
     52 
     53 

TypeError: sequence item 0: expected str instance, bytes found
```