### PR TITLE
fix: python3 support and out of order sync

### DIFF
--- a/kindle_python3.py
+++ b/kindle_python3.py
@@ -43,7 +43,7 @@ def export_txt(clips):
     """
     for book in clips:
         lines = []
-        for pos in sorted(clips[book]):
+        for pos in sorted(clips[book], key=int):
             lines.append(clips[book][pos].encode('utf-8'))
 
         filename = os.path.join(OUTPUT_DIR, u"%s.md" % book)


### PR DESCRIPTION
# Bug

There is a bug where if the location is numerically in order, but is alphabetically out of order, then the order of the highlights are wrong. 

e.g. Location 1001 vs 122

122 should precede 1001, but in the current implementation, 1001 is first